### PR TITLE
replaced timing functions with generic ones

### DIFF
--- a/mipcapi/getrealtime.c
+++ b/mipcapi/getrealtime.c
@@ -1,0 +1,132 @@
+/*
+ * Author:  David Robert Nadeau
+ * Site:    http://NadeauSoftware.com/
+ * License: Creative Commons Attribution 3.0 Unported License
+ *          http://creativecommons.org/licenses/by/3.0/deed.en_US
+ * Reference: http://nadeausoftware.com/articles/2012/04/c_c_tip_how_measure_elapsed_real_time_benchmarking
+ */
+
+#include "getrealtime.h"
+
+#if defined(_WIN32)
+#include <Windows.h>
+
+#elif defined(__unix__) || defined(__unix) || defined(unix) || (defined(__APPLE__) && defined(__MACH__))
+#include <unistd.h>	/* POSIX flags */
+#include <time.h>	/* clock_gettime(), time() */
+#include <sys/time.h>	/* gethrtime(), gettimeofday() */
+
+#if defined(__MACH__) && defined(__APPLE__)
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+#else
+#error "Unable to define getRealTime( ) for an unknown OS."
+#endif
+
+
+/**
+ * getRealMillisec() returns the real time in milliseconds
+ */
+ uint32_t getRealMillisec(void)
+ {
+ 	double d=getRealTime();
+ 	uint32_t w=floor(d);
+ 	double f=(d-w);
+ 	return (uint32_t)((w*1000)+(f*1000));
+ }
+
+
+/**
+ * Returns the real time, in seconds, or -1.0 if an error occurred.
+ *
+ * Time is measured since an arbitrary and OS-dependent start time.
+ * The returned real time is only useful for computing an elapsed time
+ * between two calls to this function.
+ */
+double getRealTime(void)
+{
+#if defined(_WIN32)
+	FILETIME tm;
+	ULONGLONG t;
+#if defined(NTDDI_WIN8) && NTDDI_VERSION >= NTDDI_WIN8
+	/* Windows 8, Windows Server 2012 and later. ---------------- */
+	GetSystemTimePreciseAsFileTime( &tm );
+#else
+	/* Windows 2000 and later. ---------------------------------- */
+	GetSystemTimeAsFileTime( &tm );
+#endif
+	t = ((ULONGLONG)tm.dwHighDateTime << 32) | (ULONGLONG)tm.dwLowDateTime;
+	return (double)t / 10000000.0;
+
+#elif (defined(__hpux) || defined(hpux)) || ((defined(__sun__) || defined(__sun) || defined(sun)) && (defined(__SVR4) || defined(__svr4__)))
+	/* HP-UX, Solaris. ------------------------------------------ */
+	return (double)gethrtime( ) / 1000000000.0;
+
+#elif defined(__MACH__) && defined(__APPLE__)
+	/* OSX. ----------------------------------------------------- */
+	static double timeConvert = 0.0;
+	if ( timeConvert == 0.0 )
+	{
+		mach_timebase_info_data_t timeBase;
+		(void)mach_timebase_info( &timeBase );
+		timeConvert = (double)timeBase.numer /
+			(double)timeBase.denom /
+			1000000000.0;
+	}
+	return (double)mach_absolute_time( ) * timeConvert;
+
+#elif defined(_POSIX_VERSION)
+	/* POSIX. --------------------------------------------------- */
+#if defined(_POSIX_TIMERS) && (_POSIX_TIMERS > 0)
+	{
+		struct timespec ts;
+#if defined(CLOCK_MONOTONIC_PRECISE)
+		/* BSD. --------------------------------------------- */
+		const clockid_t id = CLOCK_MONOTONIC_PRECISE;
+#elif defined(CLOCK_MONOTONIC_RAW)
+		/* Linux. ------------------------------------------- */
+		const clockid_t id = CLOCK_MONOTONIC_RAW;
+#elif defined(CLOCK_HIGHRES)
+		/* Solaris. ----------------------------------------- */
+		const clockid_t id = CLOCK_HIGHRES;
+#elif defined(CLOCK_MONOTONIC)
+		/* AIX, BSD, Linux, POSIX, Solaris. ----------------- */
+		const clockid_t id = CLOCK_MONOTONIC;
+#elif defined(CLOCK_REALTIME)
+		/* AIX, BSD, HP-UX, Linux, POSIX. ------------------- */
+		const clockid_t id = CLOCK_REALTIME;
+#else
+		const clockid_t id = (clockid_t)-1;	/* Unknown. */
+#endif /* CLOCK_* */
+		if ( id != (clockid_t)-1 && clock_gettime( id, &ts ) != -1 )
+			return (double)ts.tv_sec +
+				(double)ts.tv_nsec / 1000000000.0;
+		/* Fall thru. */
+	}
+#endif /* _POSIX_TIMERS */
+
+	/* AIX, BSD, Cygwin, HP-UX, Linux, OSX, POSIX, Solaris. ----- */
+	struct timeval tm;
+	gettimeofday( &tm, NULL );
+	return (double)tm.tv_sec + (double)tm.tv_usec / 1000000.0;
+#else
+	return -1.0;		/* Failed. */
+#endif
+}
+
+#ifdef _TESTING_ONLY
+int main(void)
+{
+	printf("%d\n",getRealMillisec());
+	sleep(1);
+	printf("%d\n",getRealMillisec());
+	sleep(1);
+	printf("%d\n",getRealMillisec());
+	sleep(1);
+	printf("%d\n",getRealMillisec());
+	sleep(1);
+	printf("%d\n",getRealMillisec());
+}
+#endif

--- a/mipcapi/getrealtime.h
+++ b/mipcapi/getrealtime.h
@@ -1,0 +1,17 @@
+/*
+ * Author:  David Robert Nadeau
+ * Site:    http://NadeauSoftware.com/
+ * License: Creative Commons Attribution 3.0 Unported License
+ *          http://creativecommons.org/licenses/by/3.0/deed.en_US
+ * Reference: http://nadeausoftware.com/articles/2012/04/c_c_tip_how_measure_elapsed_real_time_benchmarking
+ */
+ 
+#include <stdint.h> 
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h> 
+
+
+
+ double getRealTime(void);
+ uint32_t getRealMillisec(void);


### PR DESCRIPTION
This is an initial step to also providing a linux version of osxble based on bluez - but the OSX timing function had to be abstracted first to even make it work on linux at all.
